### PR TITLE
Add list credentials permission

### DIFF
--- a/role.tf
+++ b/role.tf
@@ -8,6 +8,7 @@ resource "azurerm_role_definition" "ksoc" {
   permissions {
     actions = [
       "Microsoft.ContainerService/managedClusters/read",
+      "Microsoft.ContainerService/managedClusters/listClusterUserCredential",
     ]
     not_actions = []
   }


### PR DESCRIPTION
This is needed to get the cluster root CA which identifies clusters in a unique way.